### PR TITLE
dynamic-hmap extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.13.5)
+
+set(CMAKE_CXX_STANDARD 17)
+set(HMAP_INCLUDE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(HMAP_LIBRARY_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+
+add_subdirectory(src)
+add_executable(test-hmap example/test-hmap.cc)
+target_include_directories(test-hmap
+        PUBLIC ${HMAP_INCLUDE_DIRECTORY}
+	       Boost::boost
+        )
+target_link_libraries(test-hmap LINK_PUBLIC dynamic-hmap)

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -70,7 +70,7 @@ int main(int argc, const char* argv[]) {
 		assert(!inserted3); // Assert that "All the hosers" went nowhere, eh
 
 		auto [iter4, inserted4] =
-		    myMap.try_emplace(dK<Foo>("crack"), "got to love"s);
+		    myMap.try_emplace(dK<Foo>("chair"), "got to love"s);
 		assert(inserted4); // Assert that "got to love" was inserted
 
 		std::cout << iter3->second.str() << ' ';

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -2,7 +2,6 @@
 #include <hmap/dynamic-hmap.hpp>
 
 #include <iostream>
-#include <string_view>
 
 using namespace std::string_literals;
 
@@ -42,7 +41,7 @@ int main(int argc, const char* argv[]) {
 			const std::string& bar_;
 		public:
 			explicit Foo(const std::string& bar) : bar_(bar) {}
-			const std::string_view str() const { return bar_; }
+			const std::string& str() const { return bar_; }
 		};
 		auto myMap = make_dynamic_hmap((dK<Foo>("baz"), Foo("Listen"s)),
 		                               (dK<Foo>("bobndoug"), Foo("hosers"s)),
@@ -115,14 +114,11 @@ int main(int argc, const char* argv[]) {
 		// Unify the boost optional and literals to a common class
 		// for use by operator <<.  We could use std::string_view,
 		// but the best option is to use C++ string literals
-		// (added by C++14) so both map and value_or will return
-		// const std::string&.
-		auto make_view = [](const std::shared_ptr<std::string>& mem)
-		    { return *mem; };
+		// (added by C++14)
 
 		auto &[optCusp, optBaz] = tup;
-		std::cout << optCusp.map(make_view).value_or("\"cusp\" is not in map"s) << std::endl;
-		std::cout << optBaz.map(make_view).value_or("\"baz\" is not in map"s) << std::endl;
+		std::cout << ((boost::none != optCusp) ? **optCusp : "\"cusp\" is not in map"s) << std::endl;
+		std::cout << ((boost::none != optBaz) ? **optBaz : "\"baz\" is not in map"s) << std::endl;
 	}
 
 	return 0;

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -49,7 +49,37 @@ int main(int argc, const char* argv[]) {
 		std::cout << myMap.erase(dK<int>("foo")) << std::endl;
 		
 		myMap[dK<std::string>("baz")] = "goodbye";
-		std::cout << myMap[dK<std::string>("baz")] << std::endl;
+		auto tup =  myMap.optCheckOut(dK<std::string>("cusp"),
+					      dK<std::string>("baz"));
+		auto &[cusp, baz] = tup;
+		std::cout << cusp.value_or("\"cusp\" is not in map") << std::endl;
+		std::cout << baz.value_or("\"baz\" is not in map") << std::endl;
+		myMap.optCheckIn(std::move(tup), dK<std::string>("cusp"),
+				 dK<std::string>("baz"));
 	}
+	{
+	  auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
+	  auto tup = myMap.shrCheckOut(dSK<std::string>("cusp"),
+				       dSK<std::string>("baz"));
+	  auto &[cusp, baz] = tup;
+	  std::cout << (cusp ? cusp->c_str() : "\"cusp\" is not in map") << std::endl;
+	  std::cout << (baz ? baz->c_str() : "\"baz\" is not in map") << std::endl;
+	  myMap.shrCheckIn(std::move(tup), dSK<std::string>("cusp"),
+                         dSK<std::string>("baz"));
+	}
+    {
+        auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
+        auto myMap2 = make_dynamic_hmap();
+        myMap2.insert(myMap.extract(dSK<std::string>("baz"), dSK<std::string>("cusp")), dSK<std::string>("baz"),
+                dSK<std::string>("cusp"));
+        auto tup = myMap2.shrCheckOut(dSK<std::string>("cusp"),
+                                     dSK<std::string>("baz"));
+        auto &[cusp, baz] = tup;
+        std::cout << (cusp ? cusp->c_str() : "\"cusp\" is not in map") << std::endl;
+        std::cout << (baz ? baz->c_str() : "\"baz\" is not in map") << std::endl;
+        myMap.shrCheckIn(std::move(tup), dSK<std::string>("cusp"),
+                         dSK<std::string>("baz"));
+    }
+
 	return 0;
 }

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -50,23 +50,25 @@ int main(int argc, const char* argv[]) {
 		
 		myMap[dK<std::string>("baz")] = "goodbye";
 		auto tup =  myMap.optCheckOut(dK<std::string>("cusp"),
-					      dK<std::string>("baz"));
+		                              dK<std::string>("baz"));
 		auto &[cusp, baz] = tup;
 		std::cout << cusp.value_or("\"cusp\" is not in map") << std::endl;
 		std::cout << baz.value_or("\"baz\" is not in map") << std::endl;
 		myMap.optCheckIn(std::move(tup), dK<std::string>("cusp"),
-				 dK<std::string>("baz"));
+		                                 dK<std::string>("baz"));
 	}
     {
-        auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
-        auto myMap2 = make_dynamic_hmap();
-        myMap2.insert(myMap.extract(dSK<std::string>("baz"), dSK<std::string>("cusp")), dSK<std::string>("baz"),
-                dSK<std::string>("cusp"));
-        auto tup = myMap2.optCheckOut(dSK<std::string>("cusp"),
-				      dSK<std::string>("baz"));
-        auto &[optCusp, optBaz] = tup;
-        std::cout << (optCusp ? (*optCusp)->c_str() : "\"cusp\" is not in map") << std::endl;
-        std::cout << (optBaz ? (*optBaz)->c_str() : "\"baz\" is not in map") << std::endl;
-    }
-    return 0;
+		auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
+		auto myMap2 = make_dynamic_hmap();
+		myMap2.insert(myMap.extract(dSK<std::string>("baz"),
+		                            dSK<std::string>("cusp")),
+		              dSK<std::string>("baz"),
+		              dSK<std::string>("cusp"));
+		auto tup = myMap2.optCheckOut(dSK<std::string>("cusp"),
+		                              dSK<std::string>("baz"));
+		auto &[optCusp, optBaz] = tup;
+		std::cout << (optCusp ? (*optCusp)->c_str() : "\"cusp\" is not in map") << std::endl;
+		std::cout << (optBaz ? (*optBaz)->c_str() : "\"baz\" is not in map") << std::endl;
+	}
+	return 0;
 }

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -2,6 +2,7 @@
 #include <hmap/dynamic-hmap.hpp>
 
 #include <iostream>
+#include <string_view>
 
 
 int main(int argc, const char* argv[]) {
@@ -66,9 +67,17 @@ int main(int argc, const char* argv[]) {
 		              dSK<std::string>("cusp"));
 		auto tup = myMap2.optCheckOut(dSK<std::string>("cusp"),
 		                              dSK<std::string>("baz"));
+		// std::string_view is an "impedance matching" wrapper class
+		// for std::string, a null-terminated C string and a C char[]
+		// with a character count.  To feed operator<<, we will map the
+		// boost::optional<std::shared_ptr<std::string> > to a
+		// boost::optional<std::string_view> and C++ will do the rest.
+		auto make_view = [](const std::shared_ptr<std::string>& mem)
+		    { return std::string_view(*mem); };
+
 		auto &[optCusp, optBaz] = tup;
-		std::cout << (optCusp ? (*optCusp)->c_str() : "\"cusp\" is not in map") << std::endl;
-		std::cout << (optBaz ? (*optBaz)->c_str() : "\"baz\" is not in map") << std::endl;
+		std::cout << optCusp.map(make_view).value_or("\"cusp\" is not in map") << std::endl;
+		std::cout << optBaz.map(make_view).value_or("\"baz\" is not in map") << std::endl;
 	}
 	return 0;
 }

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -57,29 +57,16 @@ int main(int argc, const char* argv[]) {
 		myMap.optCheckIn(std::move(tup), dK<std::string>("cusp"),
 				 dK<std::string>("baz"));
 	}
-	{
-	  auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
-	  auto tup = myMap.shrCheckOut(dSK<std::string>("cusp"),
-				       dSK<std::string>("baz"));
-	  auto &[cusp, baz] = tup;
-	  std::cout << (cusp ? cusp->c_str() : "\"cusp\" is not in map") << std::endl;
-	  std::cout << (baz ? baz->c_str() : "\"baz\" is not in map") << std::endl;
-	  myMap.shrCheckIn(std::move(tup), dSK<std::string>("cusp"),
-                         dSK<std::string>("baz"));
-	}
     {
         auto myMap = make_dynamic_hmap((dSK<std::string>("baz"),std::make_shared<std::string>("goodbye")));
         auto myMap2 = make_dynamic_hmap();
         myMap2.insert(myMap.extract(dSK<std::string>("baz"), dSK<std::string>("cusp")), dSK<std::string>("baz"),
                 dSK<std::string>("cusp"));
-        auto tup = myMap2.shrCheckOut(dSK<std::string>("cusp"),
-                                     dSK<std::string>("baz"));
-        auto &[cusp, baz] = tup;
-        std::cout << (cusp ? cusp->c_str() : "\"cusp\" is not in map") << std::endl;
-        std::cout << (baz ? baz->c_str() : "\"baz\" is not in map") << std::endl;
-        myMap.shrCheckIn(std::move(tup), dSK<std::string>("cusp"),
-                         dSK<std::string>("baz"));
+        auto tup = myMap2.optCheckOut(dSK<std::string>("cusp"),
+				      dSK<std::string>("baz"));
+        auto &[optCusp, optBaz] = tup;
+        std::cout << (optCusp ? (*optCusp)->c_str() : "\"cusp\" is not in map") << std::endl;
+        std::cout << (optBaz ? (*optBaz)->c_str() : "\"baz\" is not in map") << std::endl;
     }
-
-	return 0;
+    return 0;
 }

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -113,26 +113,29 @@ private:
 		}
 	};
 	
-    template <typename V>
-    auto extractOne(const detail::Key<V>& k) -> decltype(std::make_pair(k, std::move(map_.extract(k)))) {
-        return std::make_pair(k, std::move(map_.extract(k)));
-    }
-
-    template <typename V>
-    boost::optional<V> optCheckOutOne(const detail::Key<V>& k) {
-        boost::optional<V> retval;
-	auto mapNodeHandle = map_.extract(k);
-	if (mapNodeHandle) {
-	  retval.emplace(std::any_cast<V&&>(std::move(mapNodeHandle.mapped())));
+	template <typename V>
+	auto extractOne(const detail::Key<V>& k) -> decltype(std::make_pair(k, std::move(map_.extract(k)))) {
+		return std::make_pair(k, std::move(map_.extract(k)));
 	}
-	return retval;
-    }
-
-    template <typename... DataTypes, typename... Args, size_t... Is>
-    void insertHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
-        (static_cast<void>(insertOne(args, std::get<Is>(dataTup).first, std::move(std::get<Is>(dataTup).second))), ...);
-    }
-
+	
+	template <typename V>
+	boost::optional<V> optCheckOutOne(const detail::Key<V>& k) {
+		boost::optional<V> retval;
+		auto mapNodeHandle = map_.extract(k);
+		if (mapNodeHandle) {
+			retval.emplace(std::any_cast<V&&>(std::move(mapNodeHandle.mapped())));
+		}
+		return retval;
+	}
+	
+	template <typename... DataTypes, typename... Args, size_t... Is>
+	void insertHelper(std::tuple<DataTypes...> dataTup,
+	                  std::index_sequence<Is...>, Args&&... args) {
+		(static_cast<void>(insertOne(args, std::get<Is>(dataTup).first,
+		                             std::move(std::get<Is>(dataTup).second))),
+		 ...);
+	}
+	
 	// Insert values from a compatible node handle into the map
 	template <typename V, typename W, typename X>
 	void insertOne(const detail::Key<V>& k, const detail::Key<W>& kPrime, X&& node_handle) {
@@ -155,9 +158,9 @@ private:
 					map_.try_emplace(k, node_handle.mapped());
 				}
 			}
-        	}
+		}
 	}
-
+	
 	template <typename V>
 	boost::optional<const V&> optCopyOutOne(const detail::Key<V>& k) const {
 		boost::optional<const V&> retval;
@@ -166,6 +169,7 @@ private:
 		}
 		return retval;
 	}
+	
 	template <typename V>
 	boost::optional<V&> optCopyOutOne(const detail::Key<V>& k) {
 		boost::optional<V&> retval;
@@ -174,14 +178,14 @@ private:
 		}
 		return retval;
 	}
-
+	
 	template <typename... DataTypes, typename... Args, size_t... Is>
 	void optCheckInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
 		(static_cast<void>(optCheckInOne(std::move(std::get<Is>(dataTup)),
-										 args)),
+		                                 args)),
 		 ...);
 	}
-
+	
 	template <typename V>
 	void optCheckInOne(boost::optional<V>&& arg, const detail::Key<V>& k) {
 		if (boost::none != arg) {
@@ -193,8 +197,8 @@ private:
 			vRef = std::move(arg).value();
 		}
 	}
-
-template <typename... DataTypes, typename... Args, size_t... Is>
+	
+	template <typename... DataTypes, typename... Args, size_t... Is>
 	void optCopyInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
 		(static_cast<void>(optCopyInOne(std::move(std::get<Is>(dataTup)),
 		                                args)),
@@ -212,8 +216,6 @@ template <typename... DataTypes, typename... Args, size_t... Is>
 			vRef = std::move(arg).value();
 		}
 	}
-
-	
 
   public:
 	
@@ -355,8 +357,7 @@ template<typename ...Vs>
 DynamicHMap make_dynamic_hmap(Vs&& ...vs) {
 	DynamicHMap hmap;
 	(static_cast<void>([&hmap](auto commaPair) {
-	                       hmap.map_.try_emplace(commaPair.first,
-	                                             std::move(commaPair.second));
+	                       hmap.map_.emplace(std::move(commaPair));
 	                       }(vs)),
 	    ...);
 	return hmap;

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -122,8 +122,7 @@ private:
     boost::optional<V> optCheckOutOne(const detail::Key<V>& k) {
         boost::optional<V> retval;
 	auto mapNodeHandle = map_.extract(k);
-	if (mapNodeHandle &&
-	    (&(mapNodeHandle.key().tag.get()) == &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
+	if (mapNodeHandle) {
 	  retval.emplace(std::any_cast<V&&>(std::move(mapNodeHandle.mapped())));
 	}
 	return retval;
@@ -162,20 +161,16 @@ private:
 	template <typename V>
 	boost::optional<const V&> optCopyOutOne(const detail::Key<V>& k) const {
 		boost::optional<const V&> retval;
-		if (&(k.tag.get()) == &(const detail::KeyTagBase&)KeyTag<V>::tag()) {
-			if (auto it = map_.find(k); map_.cend() != it) {
-				retval.emplace(std::any_cast<const V&>(map_.at(k)));
-			}
+		if (auto it = map_.find(k); map_.cend() != it) {
+			retval.emplace(std::any_cast<const V&>(map_.at(k)));
 		}
 		return retval;
 	}
 	template <typename V>
 	boost::optional<V&> optCopyOutOne(const detail::Key<V>& k) {
 		boost::optional<V&> retval;
-		if (&(k.tag.get()) == &(const detail::KeyTagBase&)KeyTag<V>::tag()) {
-			if (auto it = map_.find(k); map_.end() != it) {
-				retval.emplace(std::any_cast<V&>(map_.at(k)));
-			}
+		if (auto it = map_.find(k); map_.end() != it) {
+			retval.emplace(std::any_cast<V&>(map_.at(k)));
 		}
 		return retval;
 	}
@@ -319,20 +314,20 @@ template <typename... DataTypes, typename... Args, size_t... Is>
 	auto find(const detail::Key<V>& k) {
 		iterator found = map_.find(k);
 		iterator theEnd = end();
-		return boost::make_transform_iterator<AnyCaster<V> >(((found == theEnd) || (&(found->first.tag.get()) != &(const detail::KeyTagBase&)KeyTag<V>::tag())) ? theEnd : found);
+		return boost::make_transform_iterator<AnyCaster<V> >((found == theEnd) ? theEnd : found);
 	}
 	
 	template<typename V>
 	auto find(const detail::Key<V>& k) const {
 		const_iterator found = map_.find(k);
 		const_iterator theEnd = cend();
-		return boost::make_transform_iterator<ConstAnyCaster<V> >(((found == theEnd) || (&(found->first.tag.get()) != &(const detail::KeyTagBase&)KeyTag<V>::tag())) ? theEnd : found);
+		return boost::make_transform_iterator<ConstAnyCaster<V> >((found == theEnd) ? theEnd : found);
 	}
 	
 	template<typename V>
 	size_t erase(const detail::Key<V>& k) {
 		auto found = map_.find(k);
-		if((found == map_.end()) || (&(found->first.tag.get()) != &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
+		if(found == map_.end()) {
 			return 0;
 		} else {
 			map_.erase(found);

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -357,7 +357,8 @@ template<typename ...Vs>
 DynamicHMap make_dynamic_hmap(Vs&& ...vs) {
 	DynamicHMap hmap;
 	(static_cast<void>([&hmap](auto commaPair) {
-	                       hmap.map_.emplace(std::move(commaPair));
+	                       hmap.map_.try_emplace(commaPair.first,
+	                                             std::move(commaPair.second));
 	                       }(vs)),
 	    ...);
 	return hmap;

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -76,159 +76,164 @@ namespace detail {
 		: KeyBase(k) {}
 		
 		template<class A>
-		std::pair<std::reference_wrapper<const Key<V> >, V> operator,(A&& a) const {
-		    return std::make_pair(std::cref(*this), std::forward<A>(a));
+		std::pair<std::reference_wrapper<const Key<V> >, V>
+		operator,(A&& a) const {
+			return std::make_pair(std::cref(*this), std::forward<A>(a));
 		}
 	};
 }
 
 class DynamicHMap {
 	std::map<detail::KeyBase, std::any> map_;
-
+	
 public:
 	using value_type = decltype(map_)::value_type;
 	using iterator = decltype(map_)::iterator;
 	using const_iterator = decltype(map_)::const_iterator;
-
+	
 	template<typename V> using specific_value_type = std::pair<detail::KeyBase, V&>;
 	template<typename V> using const_specific_value_type = std::pair<detail::KeyBase, const V&>;
 
 	template<typename ...Vs>
-    friend DynamicHMap make_dynamic_hmap(Vs&& ...vs);
+	friend DynamicHMap make_dynamic_hmap(Vs&& ...vs);
 
 private:
-
+	
 	template<typename V>
 	struct AnyCaster {
 		specific_value_type<V> operator()(value_type &v) const {
 			return specific_value_type<V>(v.first, std::any_cast<V&>(v.second));
 		}
 	};
-
+	
 	template<typename V>
 	struct ConstAnyCaster {
 		const_specific_value_type<V> operator()(const value_type &v) const {
 			return const_specific_value_type<V>(v.first, std::any_cast<const V&>(v.second));
 		}
 	};
-
+	
     template <typename V>
-    auto extractOne(const detail::Key<V>& k) -> decltype(std::make_pair(k, std::move(map_.extract(k)))) {
-        return std::make_pair(k, std::move(map_.extract(k)));
-    }
-
-    template <typename V>
-    boost::optional<V> optCheckOutOne(const detail::Key<V>& k) {
-        boost::optional<V> retval;
-	auto mapNodeHandle = map_.extract(k);
-	if (mapNodeHandle &&
-	    (&(mapNodeHandle.key().tag) == &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
-	  retval.emplace(std::any_cast<V&&>(std::move(mapNodeHandle.mapped())));
+	auto extractOne(const detail::Key<V>& k) -> decltype(std::make_pair(k, std::move(map_.extract(k)))) {
+		return std::make_pair(k, std::move(map_.extract(k)));
 	}
-	return retval;
-    }
-
-    template <typename... DataTypes, typename... Args, size_t... Is>
-    void insertHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
-        (static_cast<void>(insertOne(args, std::get<Is>(dataTup).first, std::move(std::get<Is>(dataTup).second))), ...);
-    }
-
+	
+	template <typename V>
+	boost::optional<V> optCheckOutOne(const detail::Key<V>& k) {
+		boost::optional<V> retval;
+		auto mapNodeHandle = map_.extract(k);
+		if (mapNodeHandle && (&(mapNodeHandle.key().tag) ==
+		                      &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
+			retval.emplace(std::any_cast<V&&>(std::move(mapNodeHandle.mapped())));
+		}
+		return retval;
+	}
+	
+	template <typename... DataTypes, typename... Args, size_t... Is>
+	void insertHelper(std::tuple<DataTypes...> dataTup,
+	                  std::index_sequence<Is...>, Args&&... args) {
+		(static_cast<void>(insertOne(args, std::get<Is>(dataTup).first,
+		                             std::move(std::get<Is>(dataTup).second))),
+		 ...);
+	}
+	
 	// Insert values from a compatible node handle into the map
 	template <typename V, typename W, typename X>
 	void insertOne(const detail::Key<V>& k, const detail::Key<W>& kPrime, X&& node_handle) {
 		if constexpr (std::is_convertible_v<W, V>) {
-		    if (node_handle) {
-			    if constexpr (std::is_same<decltype(map_.get_allocator()),
-			                               decltype(node_handle.get_allocator())>::value) {
-				     if (map_.get_allocator() == node_handle.get_allocator()) {
-				         if (k == kPrime) {
-							 map_.insert(std::move(node_handle));
-						 } else {
-				             map_.try_emplace(k, std::move(node_handle.mapped()));
-				         }
-				    } else {
-				         // Make sure we copy the value
-					     map_.try_emplace(k, node_handle.mapped());
-				    }
-			    } else {
-					// Make sure we copy the value
+			if (node_handle) {
+				if constexpr (std::is_same<decltype(map_.get_allocator()),
+				              decltype(node_handle.get_allocator())>::value) {
+						if (map_.get_allocator() == node_handle.get_allocator()) {
+							if (k == kPrime) {
+								map_.insert(std::move(node_handle));
+							} else {
+								map_.try_emplace(k, std::move(node_handle.mapped()));
+							}
+						} else {
+							// Make sure we copy the value
+							map_.try_emplace(k, node_handle.mapped());
+						}
+				} else {
+				    // Make sure we copy the value
 					map_.try_emplace(k, node_handle.mapped());
 				}
 			}
+        }
+	}
+	
+	template <typename V>
+	boost::optional<const V&> optCopyOutOne(const detail::Key<V>& k) const {
+		boost::optional<const V&> retval;
+		if (&(k.tag) == &(const detail::KeyTagBase&)KeyTag<V>::tag()) {
+			if (auto it = map_.find(k); map_.cend() != it) {
+				retval.emplace(std::any_cast<const V&>(map_.at(k)));
+			}
+		}
+		return retval;
+	}
+	
+	template <typename V>
+	boost::optional<V&> optCopyOutOne(const detail::Key<V>& k) {
+		boost::optional<V&> retval;
+		if (&(k.tag) == &(const detail::KeyTagBase&)KeyTag<V>::tag()) {
+			if (auto it = map_.find(k); map_.end() != it) {
+				retval.emplace(std::any_cast<V&>(map_.at(k)));
+			}
+		}
+		return retval;
+	}
+	
+	template <typename... DataTypes, typename... Args, size_t... Is>
+	void optCheckInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
+		(static_cast<void>(optCheckInOne(std::move(std::get<Is>(dataTup)),
+		                                 args)),
+		 ...);
+	}
+	
+	template <typename V>
+	void optCheckInOne(boost::optional<V>&& arg, const detail::Key<V>& k) {
+		if (boost::none != arg) {
+			std::any& vHolder = map_[k];
+			if (!vHolder.has_value()) {
+				vHolder.emplace<V>();  // The type must be default constructible
+			}
+			V& vRef = std::any_cast<V&>(vHolder);
+			vRef = std::move(arg).value();
+		}
+	}
+	
+	template <typename... DataTypes, typename... Args, size_t... Is>
+	void optCopyInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
+		(static_cast<void>(optCopyInOne(std::move(std::get<Is>(dataTup)),
+		                                args)),
+		 ...);
+	}
+	
+	template <typename V>
+	void optCopyInOne(boost::optional<V&>&& arg, const detail::Key<V>& k) {
+		if (boost::none != arg) {
+			std::any& vHolder = map_[k];
+			if (!vHolder.has_value()) {
+				vHolder.emplace<V>();	 // The type must be default constructible
+			}
+			V& vRef = std::any_cast<V&>(vHolder);
+			vRef = std::move(arg).value();
 		}
 	}
 
-    template <typename V>
-    boost::optional<const V&> optCopyOutOne(const detail::Key<V>& k) const {
-        boost::optional<const V&> retval;
-        if (&(k.tag) == &(const detail::KeyTagBase&)KeyTag<V>::tag())
-        {
-            if (auto it = map_.find(k); map_.cend() != it)
-            {
-                retval.emplace(std::any_cast<const V&>(map_.at(k)));
-            }
-        }
-        return retval;
-    }
-
-    template <typename V>
-    boost::optional<V&> optCopyOutOne(const detail::Key<V>& k) {
-        boost::optional<V&> retval;
-	    if (&(k.tag) == &(const detail::KeyTagBase&)KeyTag<V>::tag())
-	    {
-	        if (auto it = map_.find(k); map_.end() != it)
-	        {
-                retval.emplace(std::any_cast<V&>(map_.at(k)));
-	        }
-	    }
-	return retval;
-    }
-
-    template <typename... DataTypes, typename... Args, size_t... Is>
-    void optCheckInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
-        (static_cast<void>(optCheckInOne(std::move(std::get<Is>(dataTup)), args)), ...);
-    }
-
-    template <typename V>
-    void optCheckInOne(boost::optional<V>&& arg, const detail::Key<V>& k) {
-        if (boost::none != arg) {
-	    std::any& vHolder = map_[k];
-	    if (!vHolder.has_value()) {
-	        vHolder.emplace<V>();  // The type must be default constructible
-	    }
-	    V& vRef = std::any_cast<V&>(vHolder);
-	    vRef = std::move(arg).value();
-	}
-    }
-
-    template <typename... DataTypes, typename... Args, size_t... Is>
-    void optCopyInHelper(std::tuple<DataTypes...> dataTup, std::index_sequence<Is...>, Args&&... args) {
-        (static_cast<void>(optCopyInOne(std::move(std::get<Is>(dataTup)), args)), ...);
-    }
-
-  template <typename V>
-  void optCopyInOne(boost::optional<V&>&& arg, const detail::Key<V>& k) {
-      if (boost::none != arg) {
-	  std::any& vHolder = map_[k];
-	  if (!vHolder.has_value()) {
-	      vHolder.emplace<V>();  // The type must be default constructible
-	  }
-	  V& vRef = std::any_cast<V&>(vHolder);
-	  vRef = std::move(arg).value();
-      }
-  }
-
   public:
-
+	
 	DynamicHMap(const DynamicHMap& other);  // Copy Constructor
 	DynamicHMap(DynamicHMap&& other);       // Move Constructor
-
+	
 	DynamicHMap& operator=(const DynamicHMap& other);  // Copy Assignment Operator
 	DynamicHMap& operator=(DynamicHMap&& other);       // Move Assignment Operator
+	
 	template<typename ...Args>
 	DynamicHMap(Args&& ...args)
 	: map_(std::forward<Args>(args) ...) {}
-
+	
 	template<typename V>
 	V& operator[](const detail::Key<V>& k) {
 		std::any& vHolder = map_[k];
@@ -238,62 +243,62 @@ private:
 		// This will throw if it's not an appropriate type
 		return std::any_cast<V&>(vHolder);
 	}
-
+	
 	// Doesn't currently support various "fancy" operations
 	// If you want it, add it.
-
+	
 	template<typename V>
 	V& at(const detail::Key<V>& k) {
 		// This will throw if it's not an appropriate type
 		return std::any_cast<V&>(map_.at(k));
 	}
-
+	
 	template<typename V>
 	const V& at(const detail::Key<V>& k) const {
 		// This will throw if it's not an appropriate type
 		return std::any_cast<const V&>(map_.at(k));
 	}
-
-    template <typename... Args>
-    auto extract(Args&&... args) {
-        return std::make_tuple(extractOne(args)...);
-    }
-
-    template<typename ...Types, typename ...Args>
-    void insert(std::tuple<Types...> &&tup,
-                    Args&& ...args) {
-        insertHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
-                     std::index_sequence_for<Args...>{},
-                     std::forward<Args>(args)...);
-    }
-
-    template <typename... Args>
-    auto optCheckOut(Args&&... args) {
-        return std::make_tuple(optCheckOutOne(args)...);
-    }
-
-    template <typename... Args>
-    auto optCopyOut(Args&&... args)
-    {
-        return std::make_tuple(optCopyOutOne(args)...);
-    }
-
-    template<typename ...Types, typename ...Args>
-    void optCheckIn(std::tuple<Types...> &&tup,
-                    Args&& ...args) {
-        optCheckInHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
-                         std::index_sequence_for<Args...>{},
-                         std::forward<Args>(args)...);
-    }
-
-    template<typename ...Types, typename ...Args>
-    void optCopyIn(std::tuple<Types...> &&tup,
-		   Args&& ...args) {
-        optCopyInHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
-			std::index_sequence_for<Args...>{},
-			std::forward<Args>(args)...);
-    }
-
+	
+	template <typename... Args>
+	auto extract(Args&&... args) {
+		return std::make_tuple(extractOne(args)...);
+	}
+	
+	template<typename ...Types, typename ...Args>
+	void insert(std::tuple<Types...> &&tup,
+	            Args&& ...args) {
+		insertHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
+		             std::index_sequence_for<Args...>{},
+		             std::forward<Args>(args)...);
+	}
+	
+	template <typename... Args>
+	auto optCheckOut(Args&&... args) {
+		return std::make_tuple(optCheckOutOne(args)...);
+	}
+	
+	template <typename... Args>
+	auto optCopyOut(Args&&... args)
+	{
+		return std::make_tuple(optCopyOutOne(args)...);
+	}
+	
+	template<typename ...Types, typename ...Args>
+	void optCheckIn(std::tuple<Types...> &&tup,
+	                Args&& ...args) {
+		optCheckInHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
+		                 std::index_sequence_for<Args...>{},
+		                 std::forward<Args>(args)...);
+	}
+	
+	template<typename ...Types, typename ...Args>
+	void optCopyIn(std::tuple<Types...> &&tup,
+	               Args&& ...args) {
+		optCopyInHelper(std::forward<std::tuple<Types...> >(std::move(tup)),
+		                std::index_sequence_for<Args...>{},
+						std::forward<Args>(args)...);
+	}
+	
     iterator begin();
 	iterator end();
 	template<typename V>
@@ -329,7 +334,7 @@ private:
 	template<typename V>
 	size_t erase(const detail::Key<V>& k) {
 		auto found = map_.find(k);
-		if((found == map_.end()) || (&(found->first.tag) != &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
+		if ((found == map_.end()) || (&(found->first.tag) != &(const detail::KeyTagBase&)KeyTag<V>::tag())) {
 			return 0;
 		} else {
 			map_.erase(found);
@@ -339,26 +344,27 @@ private:
 };
 
 template<typename V>
-detail::Key<V> dK(const std::string& k){
+detail::Key<V> dK(const std::string& k) {
 	return detail::Key<V>(k);
 }
 
 template<typename V>
-detail::Key<std::shared_ptr<V> > dSK(const std::string& k){
-  return detail::Key<std::shared_ptr<V> >(k);
+detail::Key<std::shared_ptr<V> > dSK(const std::string& k) {
+	return detail::Key<std::shared_ptr<V> >(k);
 }
-
+	
 template<typename V>
-detail::Key<std::unique_ptr<V> > dUK(const std::string& k){
-  return detail::Key<std::unique_ptr<V> >(k);
+detail::Key<std::unique_ptr<V> > dUK(const std::string& k) {
+	return detail::Key<std::unique_ptr<V> >(k);
 }
-
+	
 template<typename ...Vs>
 DynamicHMap make_dynamic_hmap(Vs&& ...vs) {
-    DynamicHMap hmap;
-    (static_cast<void>([&hmap](auto commaPair) {
-			 hmap.map_.try_emplace(commaPair.first,
-					       std::move(commaPair.second));
-		       }(vs)), ...);
-    return hmap;
+	DynamicHMap hmap;
+	(static_cast<void>([&hmap](auto commaPair) {
+	                       hmap.map_.try_emplace(commaPair.first,
+	                                             std::move(commaPair.second));
+	                       }(vs)),
+	    ...);
+	return hmap;
 };

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -108,9 +108,13 @@ private:
 	
 public:
 	
-	DynamicHMap(const DynamicHMap& other);
-	DynamicHMap(DynamicHMap&& other);
+	DynamicHMap(const DynamicHMap& other); // Copy Constructor
+	DynamicHMap(DynamicHMap&& other); // Move Constructor
 	
+	DynamicHMap& operator=(const DynamicHMap& other); // Copy Assignment Operator
+	DynamicHMap& operator=(DynamicHMap&& other); // Move Assignment Operator
+
+
 	template<typename ...Args>
 	DynamicHMap(Args&& ...args)
 	: map_(std::forward<Args>(args) ...) {}
@@ -127,6 +131,18 @@ public:
 	
 	// Doesn't currently support various "fancy" operations
 	// If you want it, add it.
+	
+	template<typename V>
+	V& at(const detail::Key<V>& k) {
+		// This will throw if it's not an appropriate type
+		return std::any_cast<V&>(map_.at(k));
+	}
+
+	template<typename V>
+	const V& at(const detail::Key<V>& k) const {
+		// This will throw if it's not an appropriate type
+		return std::any_cast<const V&>(map_.at(k));
+	}
 	
 	iterator begin();
 	iterator end();

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -225,6 +225,26 @@ private:
 		return retval;
 	}
 	
+	// Copy a value from from the map, returning a const V*
+	template <typename V>
+	const V* ptrCopyOutOne(const detail::Key<V>& k) const {
+		const V* retval = nullptr;
+		if (auto it = map_.find(k); map_.cend() != it) {
+			retval = std::any_cast<const V*>(map_.at(k));
+		}
+		return retval;
+	}
+	
+	// Copy a value from from the map, returning a V*
+	template <typename V>
+	V* ptrCopyOutOne(const detail::Key<V>& k) {
+		V* retval = nullptr;
+		if (auto it = map_.find(k); map_.end() != it) {
+			retval = std::any_cast<V*>(map_.at(k));
+		}
+		return retval;
+	}
+	
 	// Insert values from boost::optional objects into the map as
 	// directed by the corresponding keys
 	template <typename... DataTypes, typename... Args, size_t... Is>
@@ -322,6 +342,14 @@ private:
 	template <typename... Args>
 	auto optCheckOut(Args&&... args) {
 		return std::make_tuple(optCheckOutOne(args)...);
+	}
+	
+	// Copy values from the map, returning pointers
+	// that refer to the values.
+	template <typename... Args>
+	auto ptrCopyOut(Args&&... args)
+	{
+		return std::make_tuple(ptrCopyOutOne(args)...);
 	}
 	
 	// Copy values from the map, returning optionals

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -19,17 +19,17 @@
  *
  ************************************************************************************/
 
+#include <algorithm>
 #include <any>
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
-#include <typeinfo>
-#include <utility>
-#include <algorithm>
 #include <tuple>
-#include <functional>
+#include <typeinfo>
 #include <type_traits>
+#include <utility>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/optional/optional.hpp>

--- a/include/hmap/hmap.hpp
+++ b/include/hmap/hmap.hpp
@@ -22,6 +22,7 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <tuple>
 
 //////////////////////////////////////////////////////////////////////////////
 // tuple_slice + slice_impl via: https://stackoverflow.com/a/40836163/2252298

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HMAP_LIBRARY_DIRECTORY})
+add_library(dynamic-hmap SHARED dynamic-hmap.cc)
+target_include_directories(dynamic-hmap
+        PUBLIC ${HMAP_INCLUDE_DIRECTORY}
+	       Boost::boost
+        )

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -20,49 +20,11 @@
 
 #include <hmap/dynamic-hmap.hpp>
 
-
+// The vtables for these classes will be generated here
 namespace detail {
 	KeyTagBase::~KeyTagBase() {}
 	
-	KeyBase::KeyBase(const std::string &ki, const KeyTagBase& ti)
-	: key(ki), tag(std::cref(ti)) {}
-	
-	KeyBase::KeyBase(const KeyBase &k)
-	: key(k.key), tag(k.tag) {}
-	
 	KeyBase::~KeyBase() {}
-	
-	bool KeyBase::operator<(const KeyBase &k) const {
-		return key < k.key || (key == k.key && &(tag.get()) < &(k.tag.get()));
-	}
-	
-	bool KeyBase::operator==(const KeyBase &k) const {
-		return key == k.key && &(tag.get()) == &(k.tag.get());
-	}
-	
-	bool KeyBase::operator!=(const KeyBase &k) const {
-		return key != k.key || &(tag.get()) != &(k.tag.get());
-	}
-}
-
-// Copy Constructor
-DynamicHMap::DynamicHMap(const DynamicHMap& other)
-: map_(other.map_) {}
-
-// Move Constructor
-DynamicHMap::DynamicHMap(DynamicHMap&& other)
-: map_(std::move(other.map_)) {}
-
-// Copy Assignment Operator
-DynamicHMap& DynamicHMap::operator=(const DynamicHMap& other) {
-	map_ = other.map_;
-	return *this;
-}
-
-// Move Assignment Operator
-DynamicHMap& DynamicHMap::operator=(DynamicHMap&& other) {
-	map_ = std::move(other.map_);
-	return *this;
 }
 
 DynamicHMap::iterator DynamicHMap::begin() {

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -25,7 +25,7 @@ namespace detail {
 	KeyTagBase::~KeyTagBase() {}
 	
 	KeyBase::KeyBase(const std::string &ki, const KeyTagBase& ti)
-	: key(ki), tag(ti) {}
+	: key(ki), tag(std::cref(ti)) {}
 	
 	KeyBase::KeyBase(const KeyBase &k)
 	: key(k.key), tag(k.tag) {}

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -45,11 +45,25 @@ namespace detail {
 	}
 }
 
+// Copy Constructor
 DynamicHMap::DynamicHMap(const DynamicHMap& other)
 : map_(other.map_) {}
 
+// Move Constructor
 DynamicHMap::DynamicHMap(DynamicHMap&& other)
 : map_(std::move(other.map_)) {}
+
+// Copy Assignment Operator
+DynamicHMap& DynamicHMap::operator=(const DynamicHMap& other) {
+	map_ = other.map_;
+	return *this;
+}
+
+// Move Assignment Operator
+DynamicHMap& DynamicHMap::operator=(DynamicHMap&& other) {
+	map_ = std::move(other.map_);
+	return *this;
+}
 
 DynamicHMap::iterator DynamicHMap::begin() {
 	return map_.begin();

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -33,15 +33,15 @@ namespace detail {
 	KeyBase::~KeyBase() {}
 	
 	bool KeyBase::operator<(const KeyBase &k) const {
-		return key < k.key;
+		return key < k.key || (key == k.key && &(tag.get()) < &(k.tag.get()));
 	}
 	
 	bool KeyBase::operator==(const KeyBase &k) const {
-		return key == k.key;
+		return key == k.key && &(tag.get()) == &(k.tag.get());
 	}
 	
 	bool KeyBase::operator!=(const KeyBase &k) const {
-		return key != k.key;
+		return key != k.key || &(tag.get()) != &(k.tag.get());
 	}
 }
 


### PR DESCRIPTION
This extends the function of dynamic-hmap by adding functions to:

extract one or more nodes from a map (extract)
insert one or more extracted nodes into a map (insert)
move one or more data items from a map into boost::optional<V> objects (optCheckOut)
move one or more data items from boost::optional<V> objects into a map (optCheckIn)
create one or more boost::optional<V&> reference objects from a map (optCopyOut)
insert one or more V& references built from boost::optional<V&> into a map (optCopyIn)
create one or more V* from a map (returning std::nullptr if there is no match) (ptrCopyOut)
conditionally insert a key-value pair into a map if one with the same key is not already present (try_emplace)
either insert a new key-value pair or assign a new value to an existing key-value pair using the specified key and value (insert_or_assign)

It supports non-default-constructible objects of type V by using find (which conditionally finds a key-value pair with a
matching key) and at (which finds a key-value pair with a matching key or throws an exception) and by adding
try_emplace and insert_or_assign (which will create a non-default-constructible V using one or more arguments
specified for the value).  It supports deferred intantiation of values specified using prvalues by try_emplace (which will
only instantiate the value if there's no matching key-value pair in the map).

It adds a new key function dSK to represent a std::shared_ptr that owns an object of specified type.

It also adds a CMake build that builds the example program and creates a dynamic library for code that uses dynamic-hmap (e.g., libdynamic-hmap.so on Linux).

If Cxx-Heterogeneous-Maps is already in use as a git submodule, this update will require changes to the parent repository's CMakeLists.txt to (a) compile the submodule and (b) build and use the submodule's dynamic library.