### PR TITLE
Static->Dynamic Key Conversions

### DIFF
--- a/include/hmap/hmap.hpp
+++ b/include/hmap/hmap.hpp
@@ -329,7 +329,7 @@ namespace detail {
 	
 	//////////////////////////////////////////////////////////////////////////////
 	// Convert a sequence of types into a balanced binary tree of types
-	template<typename Left, typename Right, size_t TargetLeft>
+	template<typename Left, typename Right, typename TargetLeft>
 	struct SplitJointIf;
 	
 	template<typename _Left, typename _Right, size_t TargetLeft>
@@ -342,7 +342,7 @@ namespace detail {
 	
 	template<typename ...Ls, typename H, typename ...Rs, size_t TargetLeft>
 	class Split<tuple<Ls...>, tuple<H, Rs...>, TargetLeft> {
-		using IfThunk = SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, TargetLeft>;
+		using IfThunk = SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, std::integral_constant<std::size_t, TargetLeft> >;
 	public:
 		using Left = typename IfThunk::Left;
 		using Here = typename IfThunk::Here;
@@ -354,10 +354,11 @@ namespace detail {
 		}
 	};
 	
-	template<typename Left, typename Right, size_t TargetLeft>
+	// Note: integral constant required per gcc missing implementation of http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0263r1.html#1315
+	template<typename Left, typename Right, typename TargetLeft>
 	struct SplitJointIf {};
 	template<typename ...Ls, typename H, typename ...Rs>
-	struct SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, sizeof...(Ls)> {
+	struct SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, std::integral_constant<std::size_t, sizeof...(Ls)> > {
 		using Left = tuple<Ls...>;
 		using Here = H;
 		using Right = tuple<Rs...>;
@@ -371,7 +372,7 @@ namespace detail {
 	};
 	
 	template<typename ...Ls, typename H, typename ...Rs, size_t TargetLeft>
-	struct SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, TargetLeft> {
+	struct SplitJointIf<tuple<Ls...>, tuple<H, Rs...>, std::integral_constant<std::size_t, TargetLeft> > {
 	private:
 		static_assert(sizeof...(Ls) < TargetLeft, "Missed the loop exit condition");
 		using SplitThunk = Split<tuple<Ls..., H>, tuple<Rs...>, TargetLeft>;
@@ -645,7 +646,7 @@ HMap<typename Values::KeyType...> make_hmap(Values&& ...values) {
 	return HMap<typename Values::KeyType...>(std::forward<Values>(values)...);
 }
 
-#define TK(stringliteral,T) keyType<T>([](){ return stringliteral; })
-#define IK(stringliteral) inferredKeyType([](){ return stringliteral; })
+#define TK(stringliteral,T) keyType<T>([]() constexpr { return stringliteral; })
+#define IK(stringliteral) inferredKeyType([]() constexpr { return stringliteral; })
 //////////////////////////////////////////////////////////////////////////////
 

--- a/include/hmap/hmap.hpp
+++ b/include/hmap/hmap.hpp
@@ -50,7 +50,6 @@ constexpr auto tuple_slice(Cont&& t)
 //////////////////////////////////////////////////////////////////////////////
 
 namespace detail {
-	using std::array;
 	using std::integral_constant;
 	using std::make_tuple;
 	using std::size_t;

--- a/include/hmap/hmap.hpp
+++ b/include/hmap/hmap.hpp
@@ -19,9 +19,7 @@
  *
  ************************************************************************************/
 
-#include <array>
 #include <string_view>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <tuple>

--- a/include/hmap/hmap.hpp
+++ b/include/hmap/hmap.hpp
@@ -74,13 +74,15 @@ namespace detail {
 		constexpr static const bool value = true;
 	};
 	
-	template<typename Value, char ...Cs> struct ValueType;
+	namespace detail {
+		template<typename Value, char ...Cs> struct ValueType;
+	};
 	
 	template<typename _Value, char ...Cs> struct KeyType : CharList<Cs...> {
 		using Typeless = CharList<Cs...>;
 		using Typeless::c_str;
 		using Value = _Value;
-		using ValueType = ValueType<Value, Cs...>;
+		using ValueType = detail::ValueType<Value, Cs...>;
 		
 		template<typename Arg>
 		constexpr ValueType operator,(Arg &&a) {
@@ -99,12 +101,14 @@ namespace detail {
 		constexpr static const bool value = true;
 	};
 	
-	template<typename Value, char ...Cs> struct ValueType : KeyType<Value, Cs...> {
-		using KeyType = KeyType<Value, Cs...>;
-		using KeyType::c_str;
-		Value v;
-		constexpr ValueType(Value vi) : v(vi) {}
-	};
+	namespace detail {
+		template<typename Value, char ...Cs> struct ValueType : KeyType<Value, Cs...> {
+			using ValueKeyType = KeyType<Value, Cs...>;
+			using ValueKeyType::c_str;
+			Value v;
+			constexpr ValueType(Value vi) : v(vi) {}
+		};
+	}
 	
 	template<typename Left, typename Right, bool b>
 	struct TakeLesser {

--- a/include/hmap/key-convert.hpp
+++ b/include/hmap/key-convert.hpp
@@ -1,0 +1,31 @@
+#pragma once
+/************************************************************************************
+ *
+ * Author: Thomas Dickerson
+ * Copyright: 2019 - 2020, Geopipe, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************************/
+
+#include "hmap.hpp"
+#include "dynamic-hmap.hpp"
+
+using detail::Key;
+using detail::KeyType;
+
+template<typename Value, char ...Cs>
+Key<Value> staticToDynamicKey(KeyType<Value, Cs...> key) {
+	return dK<Value>(key.c_str());
+}

--- a/include/hmap/key-convert.hpp
+++ b/include/hmap/key-convert.hpp
@@ -19,13 +19,10 @@
  *
  ************************************************************************************/
 
-#include "hmap.hpp"
-#include "dynamic-hmap.hpp"
-
-using detail::Key;
-using detail::KeyType;
+#include <hmap/hmap.hpp>
+#include <hmap/dynamic-hmap.hpp>
 
 template<typename Value, char ...Cs>
-Key<Value> staticToDynamicKey(KeyType<Value, Cs...> key) {
-	return dK<Value>(key.c_str());
+detail::Key<Value> staticToDynamicKey(detail::KeyType<Value, Cs...>) {
+	return dK<Value>(detail::KeyType<Value, Cs...>::c_str());
 }


### PR DESCRIPTION
Introduces static-to-dynamic key conversion, plus a test that populates a dynamic hmap from a tuple of static keys and ensures that only the correct set of keys are present in the dynamic hmap.

As a side-effect of my toolchain, it also includes repairs to support of g++ 7.5 and above, primarily effected by @elfprince13 .