### PR TITLE
Unsafe Insert or Assign

### DIFF
--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -52,10 +52,6 @@ struct KeyToKeyMapper<std::tuple<detail::KeyType<V, Cs...>, TailKs...>> {
   }
 };
 
-const auto inputKeys2 = KeyToKeyMapper<std::remove_cv<decltype(Keys2)>::type>::apply();
-const auto keyInfo2 = std::apply(make_hmap, inputKeys2);
-//const auto keyInfo3 = std::apply(make_hmap, KeyToKeyMapper<std::remove_cv<decltype(Keys3)>::type>::apply());
-
 int main(int argc, const char* argv[]) {
 	// Verify proper functionality of the static hmap (positive and negative tests)
 	{
@@ -198,8 +194,6 @@ int main(int argc, const char* argv[]) {
 		for(const auto& keyBase : instantDynamicKeys) {
 			std::cout << keyBase.key << std::endl;
 		}
-
-		std::cout << typeid(inputKeys2).name() << std::endl;
 	}
 	/*
 	// Test intelligently setting/getting keys from a dynamic HMap using information in a static HMap.

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -6,6 +6,56 @@
 
 using namespace std::string_literals;
 
+template<typename KeyInfo>
+struct accessor {
+	template<typename StringHolder>
+	static auto& get(DynamicHMap& dynamicHMap, KeyInfo& keyInfo, StringHolder holder) {
+		return dynamicHMap[keyInfo[inferredKeyType(holder)]];
+	}
+};
+
+#define getRef(map, keyInfo, stringliteral) accessor<decltype(keyInfo)>::get(map, keyInfo, []() constexpr { return stringliteral; })
+
+/*
+class MyTestClass {
+  public:
+	const static constexpr auto Keys = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+
+	const static decltype(std::apply([](auto ...key) {
+			return make_hmap((TK(decltype(key)::Typeless::c_str(), detail::Key<typename decltype(key)::Value>), staticToDynamicKey(key)) ...);
+		}, MyTestClass::Keys)) KeyInfo;
+};
+
+const auto keyInfo = std::apply([](auto ...key) {
+	return make_hmap((TK(decltype(key)::Typeless::c_str(), detail::Key<typename decltype(key)::Value>), staticToDynamicKey(key)) ...);
+}, MyTestClass::Keys);
+*/
+
+const constexpr auto Keys2 = std::make_tuple(TK("foo",int));
+const constexpr auto Keys3 = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+
+template<typename Tuple>
+struct KeyToKeyMapper {};
+
+template<>
+struct KeyToKeyMapper<std::tuple<>> {
+  static std::tuple<> apply(){
+    return std::tuple<>();
+  }
+};
+
+template<typename V, typename ...TailKs, char ...Cs>
+struct KeyToKeyMapper<std::tuple<detail::KeyType<V, Cs...>, TailKs...>> {
+  static auto apply() {
+    using MetaKey = detail::KeyType<detail::Key<V>, Cs...>;
+    return std::tuple_cat(std::make_tuple((MetaKey(), detail::Key<V>(MetaKey::c_str()))), KeyToKeyMapper<std::tuple<TailKs...>>::apply());
+  }
+};
+
+const auto inputKeys2 = KeyToKeyMapper<std::remove_cv<decltype(Keys2)>::type>::apply();
+const auto keyInfo2 = std::apply(make_hmap, inputKeys2);
+//const auto keyInfo3 = std::apply(make_hmap, KeyToKeyMapper<std::remove_cv<decltype(Keys3)>::type>::apply());
+
 int main(int argc, const char* argv[]) {
 	// Verify proper functionality of the static hmap (positive and negative tests)
 	{
@@ -148,6 +198,19 @@ int main(int argc, const char* argv[]) {
 		for(const auto& keyBase : instantDynamicKeys) {
 			std::cout << keyBase.key << std::endl;
 		}
+
+		std::cout << typeid(inputKeys2).name() << std::endl;
 	}
+	/*
+	// Test intelligently setting/getting keys from a dynamic HMap using information in a static HMap.
+	{
+		auto dynamicHMap = make_dynamic_hmap();
+		getRef(dynamicHMap, keyInfo, "bar") = 3.1415;
+		getRef(dynamicHMap, keyInfo, "foo") = 1337;
+		getRef(dynamicHMap, keyInfo, "baz") = "22/7";
+
+		std::cout << getRef(dynamicHMap, keyInfo, "bar") << ", " << getRef(dynamicHMap, keyInfo, "foo")<< ", " << getRef(dynamicHMap, keyInfo, "baz") << std::endl;
+	}
+	*/
 	return 0;
 }

--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -125,7 +125,7 @@ int main(int argc, const char* argv[]) {
 	}
 	// Test moving keys from a static keys into a dynamic hmap
 	{
-		auto keys = std::forward_as_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+		auto keys = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
 		auto myDynamicHMap = make_dynamic_hmap();
 		std::apply([&myDynamicHMap](auto&&... key) {
 			((myDynamicHMap[staticToDynamicKey(key)]), ...); }, keys);
@@ -136,6 +136,18 @@ int main(int argc, const char* argv[]) {
 		assert(myDynamicHMap.end<std::string>() != myDynamicHMap.find(dK<std::string>("baz")));
 		assert(myDynamicHMap.end<std::string>() == myDynamicHMap.find(dK<std::string>("cusp")));
 		assert(myDynamicHMap.end<double>() == myDynamicHMap.find(dK<double>("foo")));
+	}
+	// Test turning static keys into dynamic keys
+	{
+		auto keys = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+
+		auto instantDynamicKeys = std::apply([](auto&& ...key) {
+			return std::set<detail::KeyBase>({staticToDynamicKey(key) ...});
+		}, keys);
+
+		for(const auto& keyBase : instantDynamicKeys) {
+			std::cout << keyBase.key << std::endl;
+		}
 	}
 	return 0;
 }

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -365,6 +365,10 @@ class DynamicHMap {
 		return std::make_pair(boost::make_transform_iterator<AnyCaster<V> >(iter),
 							  inserted);
 	}
+	template<typename A>
+	auto unsafe_insert_or_assign(const detail::KeyBase& kB, A&& a) {
+		return map_.insert_or_assign(kB, std::forward<A>(a));
+	}
 
 	// Extract key-value pairs from map for insert into another map
 	template <typename... Args>

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -144,7 +144,7 @@ class DynamicHMap {
 	                            std::index_sequence<I...>) {
 		(static_cast<void>(map_.emplace_hint(map_.cend(), std::move(a[I]))),
 		 ...);
-}
+	}
 	
 	// Move N sorted key-value pairs into array in key order in O(N) time
 	template <size_t N, typename Indices = std::make_index_sequence<N> >


### PR DESCRIPTION
Adds:

1. Test for `staticToDynamicKey()`
2. New `DynamicHMap::unsafe_insert_or_assign()` method, as suggested for @elfprince13