### PR TITLE
Fix any_cast-related error in ptrCopyOut / ptrCopyOutOne

### DIFF
--- a/example/test-hmap.cc
+++ b/example/test-hmap.cc
@@ -125,7 +125,7 @@ int main(int argc, const char* argv[]) {
 	}
 	// Test moving keys from a static keys into a dynamic hmap
 	{
-		auto keys = std::forward_as_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+		auto keys = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
 		auto myDynamicHMap = make_dynamic_hmap();
 		std::apply([&myDynamicHMap](auto&&... key) {
 			((myDynamicHMap[staticToDynamicKey(key)]), ...); }, keys);
@@ -136,6 +136,18 @@ int main(int argc, const char* argv[]) {
 		assert(myDynamicHMap.end<std::string>() != myDynamicHMap.find(dK<std::string>("baz")));
 		assert(myDynamicHMap.end<std::string>() == myDynamicHMap.find(dK<std::string>("cusp")));
 		assert(myDynamicHMap.end<double>() == myDynamicHMap.find(dK<double>("foo")));
+	}
+	// Test turning static keys into dynamic keys
+	{
+		auto keys = std::make_tuple(TK("foo",int), TK("bar",float), TK("baz",std::string));
+
+		auto instantDynamicKeys = std::apply([](auto&& ...key) {
+			return std::set<detail::KeyBase>({staticToDynamicKey(key) ...});
+		}, keys);
+
+		for(const auto& keyBase : instantDynamicKeys) {
+			std::cout << keyBase.key << std::endl;
+		}
 	}
 	return 0;
 }

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -2,7 +2,7 @@
 /************************************************************************************
  *
  * Author: Thomas Dickerson
- * Copyright: 2019 - 2020, Geopipe, Inc.
+ * Copyright: 2019 - 2021, Geopipe, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -96,10 +96,10 @@ namespace detail {
 		template<class A>
 		std::pair<KeyBase, std::any>
 		operator,(A&& a) const {
-			return std::pair<KeyBase, std::any>(std::piecewise_construct,
-			                                    std::forward_as_tuple(std::cref(*((KeyBase *)this))),
-			                                    std::forward_as_tuple(std::any{std::in_place_type<V>,
-			                                                                   std::forward<A>(a)}));
+			return {std::piecewise_construct,
+			    std::forward_as_tuple(std::cref(*((KeyBase *)this))),
+			    std::forward_as_tuple(std::any{std::in_place_type<V>,
+			                                   std::forward<A>(a)})};
 		}
 	};
 }
@@ -198,7 +198,7 @@ class DynamicHMap {
 	
 	// Extract a single key-value pair from the map, returning a type tag-node handle pair
 	template <typename V>
-	auto extractOne(const detail::Key<V>& k) -> decltype(std::make_pair(k, std::move(map_.extract(k)))) {
+	decltype(auto) extractOne(const detail::Key<V>& k) {
 		return std::make_pair(k, std::move(map_.extract(k)));
 	}
 	
@@ -485,8 +485,6 @@ class DynamicHMap {
 		}
 	}
 
-	void print(std::ostream& o) const;
-
 };
 
 template<typename V>
@@ -502,4 +500,4 @@ detail::Key<std::shared_ptr<V> > dSK(const std::string& k) {
 template<typename ...Vs>
 DynamicHMap make_dynamic_hmap(Vs&& ...vs) {
 	return DynamicHMap(std::in_place, std::forward<Vs>(vs)...);
-};
+}

--- a/include/hmap/dynamic-hmap.hpp
+++ b/include/hmap/dynamic-hmap.hpp
@@ -300,9 +300,10 @@ class DynamicHMap {
 	DynamicHMap(Args&& ...args)
 	: map_(std::forward<Args>(args) ...) {}
 	
-	
 	// Construct a DynamicHMap by using Key<V>, std::any pairs,
 	// casting Key<V> to KeyBase to perform type erasure.
+	DynamicHMap(std::in_place_t) { }
+
 	template<typename ...Vs>
 	DynamicHMap(std::in_place_t, Vs&& ...vs) {
 		std::array<std::pair<detail::KeyBase, std::any>, sizeof...(Vs)> argArray

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -43,3 +43,18 @@ DynamicHMap::const_iterator DynamicHMap::cend() const {
 
 size_t DynamicHMap::size() const { return map_.size(); }
 bool DynamicHMap::empty() const { return map_.empty(); }
+
+void DynamicHMap::print(std::ostream& o) const {
+	o << "DynamicHMap Keys: ";
+	o.flush();
+	bool first = true;
+	for (const auto& pair : map_) {
+		if (!first) {
+			o << ", ";
+		} else {
+			first = false;
+		}
+		o << pair.first.key;
+	}
+	o << std::endl;
+}

--- a/src/dynamic-hmap.cc
+++ b/src/dynamic-hmap.cc
@@ -43,18 +43,3 @@ DynamicHMap::const_iterator DynamicHMap::cend() const {
 
 size_t DynamicHMap::size() const { return map_.size(); }
 bool DynamicHMap::empty() const { return map_.empty(); }
-
-void DynamicHMap::print(std::ostream& o) const {
-	o << "DynamicHMap Keys: ";
-	o.flush();
-	bool first = true;
-	for (const auto& pair : map_) {
-		if (!first) {
-			o << ", ";
-		} else {
-			first = false;
-		}
-		o << pair.first.key;
-	}
-	o << std::endl;
-}


### PR DESCRIPTION
This pull request adds fixes to the ptrCopyOut and ptrCopyOutOne functions so they won't throw an any_cast exception and a print function to help with debugging.